### PR TITLE
Only update bugzilla comments

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -151,9 +151,10 @@ struct Comment { string url, body_; }
 
 Comment getBotComment(string commentsURL)
 {
+    // the bot may post multiple comments (mention-bot & bugzilla links)
     auto res = requestHTTP(commentsURL, (scope req) { req.headers["Authorization"] = githubAuth; })
         .readJson[]
-        .find!(c => c["user"]["login"] == "dlang-bot");
+        .find!(c => c["user"]["login"] == "dlang-bot" && c["body"].get!string.canFind("Bugzilla"));
     if (res.length)
         return deserializeJson!Comment(res[0]);
     return Comment();


### PR DESCRIPTION
I believe this could be and issue with mention-bot and Bugzilla comment conflicting itself.
Note that due to the missing tests, this change is done more or less "blindly" trusting the API docs:
https://developer.github.com/v3/issues/comments/